### PR TITLE
Added handling of non yaml file types as strings

### DIFF
--- a/src/yamlinclude/constructor.py
+++ b/src/yamlinclude/constructor.py
@@ -127,10 +127,17 @@ class YamlIncludeConstructor:
             for path in iterator:
                 if os.path.isfile(path):
                     with io.open(path, encoding=encoding) as fp:  # pylint:disable=invalid-name
-                        result.append(yaml.load(fp, type(loader)))
+                        result.append(YamlIncludeConstructor.loadYaml(path,fp,loader))
             return result
         with io.open(pathname, encoding=encoding) as fp:  # pylint:disable=invalid-name
-            return yaml.load(fp, type(loader))
+            return YamlIncludeConstructor.loadYaml(pathname,fp,loader)
+
+    @classmethod
+    def loadYaml(cls, path, file, loader):
+        if path.lower().endswith(('.yaml', '.yml')):
+            return yaml.load(file, type(loader))
+        else:
+            return file.read()
 
     @classmethod
     def add_to_loader_class(cls, loader_class=None, tag=None, **kwargs):
@@ -180,10 +187,7 @@ class YamlIncludeConstructor:
             raise ValueError('`tag` argument should start with character "!"')
         instance = cls(**kwargs)
         if loader_class is None:
-            if FullLoader:
-                yaml.add_constructor(tag, instance, FullLoader)
-            else:
-                yaml.add_constructor(tag, instance)
+            yaml.add_constructor(tag, instance)
         else:
             yaml.add_constructor(tag, instance, loader_class)
         return instance


### PR DESCRIPTION
I have a use case when I want to include a bash code or a JSON file into the yaml as strings. When loading everything as YAML such include results with an error. Adding a wildcard to load `*.yaml` or `*.yml` files with YAML loader and others read as plain string solves the issue.

```yaml
compute:
  shell: sh
  command: !include script.sh
```
```bash
apk update; apk add bash;
prepare() {
  echo "Changing working directo to: $work_dir" ;
  cd "$work_dir" ;
  pwd ;
  printf "$(date) " ; echo "Starting ioping prep with truncate." ;
  eval truncate $env_prepare_args ;
  printf "$(date) " ; echo "ioping prep end" ;
} ;
compute() {
  printf "$(date)" ; echo "Starting computation sysbench run." ;
  bash -c 'eval ioping $0 | tee >(sed -ne "/ioping statistics/,$ p" > /results/compute_results)' "$env_compute_args" ;
  printf "$(date) " ; echo "sysbench compute end" ;
} ;
clean() {
  printf "$(date)" ; echo "Starting cleaning." ;
  echo "No cleaning needed." ;
  printf "$(date) " ; echo "clean end" ;
} ;
```