### PR TITLE
Add PlainTextReader to readers.py::__all__

### DIFF
--- a/src/yamlinclude/readers.py
+++ b/src/yamlinclude/readers.py
@@ -16,7 +16,7 @@ except ImportError:
     toml = None
 
 __all__ = ['READER_TABLE', 'get_reader_class_by_path', 'get_reader_class_by_name',
-           'Reader', 'IniReader', 'JsonReader', 'TomlReader', 'YamlReader']
+           'Reader', 'IniReader', 'JsonReader', 'TomlReader', 'YamlReader', 'PlainTextReader']
 
 
 def get_reader_class_by_name(name):  # type:(str)->type


### PR DESCRIPTION
All readers defined in [readers.py](https://github.com/tanbro/pyyaml-include/blob/master/src/yamlinclude/readers.py) are importable except [PlainTextReader](https://github.com/tanbro/pyyaml-include/blob/c1273c467e037a989abff5c4c48cc1e8b363da60/src/yamlinclude/readers.py#L102).

This PR adds [PlainTextReader](https://github.com/tanbro/pyyaml-include/blob/c1273c467e037a989abff5c4c48cc1e8b363da60/src/yamlinclude/readers.py#L102) to [readers.py::\_\_all\_\_](https://github.com/tanbro/pyyaml-include/blob/c1273c467e037a989abff5c4c48cc1e8b363da60/src/yamlinclude/readers.py#L18) so that it can be imported like `from yamlinclude import PlainTextReader`