### PR TITLE
Return txt files as list separated by newline

### DIFF
--- a/src/yamlinclude/readers.py
+++ b/src/yamlinclude/readers.py
@@ -103,7 +103,7 @@ class PlainTextReader(Reader):
     # pylint: disable=too-few-public-methods
     def __call__(self):
         with io.open(self._path, encoding=self._encoding) as fp:
-            return fp.read()
+            return list(map(str.rstrip, fp.readlines()))
 
 
 READER_TABLE = [


### PR DESCRIPTION
I'm not sure what the orginal intention with the `PlainTextReader` was. In my use cases, plain texts are used to contain lists, each line representing a new item in a list.

Without this commit, using PlainText reader in sequence mode has the following behavior.
`1.txt` is:
```
foo
bar
```
`2.txt` is:
```
baz
bah
```

### Sequence

If `foo.yml` was:

```yaml
files:
  - !include include.d/1.txt
  - !include include.d/2.txt
```

We'll get:

```yaml
files:
  - 'foo\nbar\n'
  - 'baz\nbah\n'
```

With this commit you woud get 
```yaml
files:
  - [ 'foo', 'bar' ]
  - [ 'baz', 'bah' ]
```

This is more intuitive to me, but perhaps that is only because of my specific use case.

