### PR TITLE
Added feature persist anchors to included yaml files

### DIFF
--- a/src/yamlinclude/readers.py
+++ b/src/yamlinclude/readers.py
@@ -62,13 +62,25 @@ class TomlReader(Reader):
 
 
 class YamlReader(Reader):
-    def __init__(self, path, encoding, loader_class, *args, **kwargs):
+    def __init__(self, path, encoding, loader, persist_anchors, *args, **kwargs):
         super().__init__(path, encoding)
-        self._loader_class = loader_class
+        self._loader_class = type(loader)
+        self._persist_anchors = persist_anchors
+        if self._persist_anchors:
+            self.anchors = loader.anchors
 
     def __call__(self):
         with open(self._path, encoding=self._encoding) as fp:
-            return yaml.load(fp, self._loader_class)  # type: ignore
+            if self._persist_anchors:
+                loader = self._loader_class(fp)
+                if self.anchors:
+                    loader.anchors = self.anchors
+                try:
+                    return loader.get_single_data()
+                finally:
+                    loader.dispose()
+            else:
+                return yaml.load(fp, self._loader_class)  # type: ignore
 
 
 class PlainTextReader(Reader):

--- a/tests/test_custome_reader.py
+++ b/tests/test_custome_reader.py
@@ -23,9 +23,9 @@ class Reader(object):
 
 class YamlReader(Reader):
     # pylint: disable=too-few-public-methods
-    def __init__(self, path, encoding, loader_class, *args, **kwargs):  # pylint:disable=unused-argument
+    def __init__(self, path, encoding, loader, *args, **kwargs):  # pylint:disable=unused-argument
         super(YamlReader, self).__init__(path, encoding)
-        self._loader_class = loader_class
+        self._loader_class = type(loader)
 
     def __call__(self):
         with io.open(self._path, encoding=self._encoding) as fp:


### PR DESCRIPTION
Hi tanbro, I thought it would be nice if this library also supported anchors when including a yaml file so I wrote this PR. I based code for this update on this stack over flow thread https://stackoverflow.com/questions/44910886/pyyaml-include-file-and-yaml-aliases-anchors-references 

Below is an example for how the new feature works:

## group.yml
```
group
  user:
    name: noah
    team: *team 
  user:
    name: aron
    team *team
```
## devops.yml
```
team: &team devops
devops: !include group.yml
```
## output.yml
```
devops:
  group
    user:
      name: noah
      team: devops 
    user:
      name: aron
      team: devops
```
