### PR TITLE
Correct license field in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 keywords = ["yaml", "PyYAML", "include"]
 
-license = {text = "AGPLv3+"}
+license = {text = "GPLv3+"}
 
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
This field causes tools such as Snyk to list this project as having an AGPL license, which does not match the LICENSE file.