### PR TITLE
fix issue if glob_params is not int

### DIFF
--- a/src/yaml_include/constructor.py
+++ b/src/yaml_include/constructor.py
@@ -374,7 +374,10 @@ class Constructor:
                 glob_fn = lambda: self.fs.glob(urlpath, *pos_args)  # noqa: E731
             else:
                 # special for maxdepth, because PyYAML sometimes treat number as string for constructor's parameter
-                maxdepth = int(glob_params)
+                try:
+                    maxdepth = int(glob_params)
+                except ValueError as e:
+                    maxdepth = None
                 glob_fn = lambda: self.fs.glob(urlpath, maxdepth=maxdepth)  # noqa: E731
 
             if open_params is None:


### PR DESCRIPTION
Hi,
I want to parse the yaml files from the AMIRIS examples repository:
https://gitlab.com/dlr-ve/esy/amiris/examples/-/blob/v2.1.0/Germany2019/scenario.yaml?ref_type=tags#L503

We have an include like this in there:
`Contracts: !include ["contracts/*.yaml", "Contracts"]`

where the last string is not of any further meaning - I can not change these files either.

Currently, this gives a ValueError as it is tried to be read as an integer.
I can confirm that this was working in the 1.x version?

So it would be very cool to have this workaround included! :)